### PR TITLE
Add GZS 197.7 OMVFM (USA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ An attempt to list the awesome radio stations, around the world, powered by the 
 - [K-PHRED RADIO](https://linkedlocalnetwork.com/)
 - [Animikii Club](https://animikii.club/)
 - [91.3 Ayclt FM](https://www.913aycltfm.com/)
+- [GZS 197.7 OMVFM](https://nicheof.one/radio/)
 
 ## Zimbabwe
 - [Radio Zimbabwe](http://154.120.239.26/public/radio_zim)


### PR DESCRIPTION
Adding **GZS 197.7 OMVFM** — the Omniversal Frequency Modulation — under USA.

A 24/7 lore-driven pirate station of AI-forged music from a roster of fictional bands. Powered by AzuraCast.

Public page: https://nicheof.one/radio/ (returns 200).